### PR TITLE
Fix server crash and Infested Weath growth

### DIFF
--- a/src/main/java/com/miskatonicmysteries/common/feature/recipe/rite/summon/ByakheeSummoningRite.java
+++ b/src/main/java/com/miskatonicmysteries/common/feature/recipe/rite/summon/ByakheeSummoningRite.java
@@ -7,6 +7,8 @@ import com.miskatonicmysteries.common.entity.HasturCultistEntity;
 import com.miskatonicmysteries.common.feature.spell.Spell;
 import com.miskatonicmysteries.common.registry.*;
 import com.miskatonicmysteries.common.util.Constants;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.model.Model;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
@@ -62,6 +64,7 @@ public class ByakheeSummoningRite extends SummoningRite {
         super.onFinished(octagram);
     }
 
+    @Environment(EnvType.CLIENT)
     @Override
     protected Model getRenderedModel(OctagramBlockEntity entity) {
         return ByakheeEntityRenderer.MODEL;

--- a/src/main/java/com/miskatonicmysteries/mixin/CropBlockMixin.java
+++ b/src/main/java/com/miskatonicmysteries/mixin/CropBlockMixin.java
@@ -19,7 +19,6 @@ public abstract class CropBlockMixin extends Block {
         super(settings);
     }
 
-    @Environment(EnvType.CLIENT)
     @Inject(method = "withAge", at = @At("HEAD"), cancellable = true)
     public void infestedWheatWithAge(int age, CallbackInfoReturnable<BlockState> cir) {
         if (getDefaultState().getBlock() == Blocks.WHEAT && age == 6 && Math.random() < MiskatonicMysteries.config.world.infestedWheatChance) {


### PR DESCRIPTION
Infested Weath does not grow on (dedicated) servers because the mixin method has an `@Environment(EnvType.CLIENT)` that's not supposed to be there:
https://github.com/cybercat5555/Miskatonic-Mysteries-Fabric/blob/626ac4d980b12be5ddf2dc310679fbf9d383d582/src/main/java/com/miskatonicmysteries/mixin/CropBlockMixin.java#L22-L28

While trying the fix I also ran into a server crash due to `ByakheeSummoningRite` implementing the client-side `getRenderedModel` this time *without* `@Environment(EnvType.CLIENT)`, so the server would crash because it couldn't find the `Model` class.