### PR TITLE
Fix book contents not being loaded (and actually apply obfuscation)

### DIFF
--- a/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/goo/hastur.json
+++ b/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/goo/hastur.json
@@ -13,18 +13,18 @@
       "text": "His very aura is known to grant people amazing artistic skills, be it only to express their unending fascination.$(br)Worshipers often feel the need to spread the Sign far and wide, inducting others. The King’s followers are all artists, and some are also known to be blessed with some of the strongest of all magics that the Old Ones can bestow on mortals."
     },
     {
-      "type": "miskatonicmysteries:obfuscated",
+      "type": "text",
       "title": "The King's Shadow",
       "obfuscated_title": "King Shadow",
       "stage": 1,
       "obfuscated_text": "$(br2)King is art and a lot of it like daffodils and rosemary and caviar from the dirty pond no thoughts head empty only art",
-      "text": "$(br2)The Yellow King, in many ways, is the expression of the creation of art as a whole. Those feeling the royal exertion of the fields of daffodils and primroses are possessed with the need to create art and express their inner thoughts, be they rational or not."
+      "text": "$(obfs:;1)$(br2)The Yellow King, in many ways, is the expression of the creation of art as a whole. Those feeling the royal exertion of the fields of daffodils and primroses are possessed with the need to create art and express their inner thoughts, be they rational or not."
     },
     {
-      "type": "miskatonicmysteries:obfuscated",
+      "type": "text",
       "stage": 1,
       "obfuscated_text": "Art is truest, for it is all that we see$(br)Keep remaking, never let it be$(br)You searched for true power, but now all you found$(br)Is the beauty in it, immensely profound.",
-      "text": "The art is thus a conduit, encouraging others to feed the cycle of creation.$(br)Everything is beautiful, everything is art, everything has to be created, and everything has to be digested in the hearts and minds of everyone else. Understood, read, and later mutated and changed until it is nothing but a simulacra of itself."
+      "text": "$(obfs:;1)The art is thus a conduit, encouraging others to feed the cycle of creation.$(br)Everything is beautiful, everything is art, everything has to be created, and everything has to be digested in the hearts and minds of everyone else. Understood, read, and later mutated and changed until it is nothing but a simulacra of itself."
     }
   ]
 }

--- a/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/goo/hastur_path.json
+++ b/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/goo/hastur_path.json
@@ -32,18 +32,18 @@
       "text": "Give your newly created piece of art to a $(marked)Yellow Vassal$(). They will quickly introduce you, setting your path towards the Yellow King.$(br2)From there on, your ascent is most likely set in stone. You do not have any of the King's powers yet, but soon you will."
     },
     {
-      "type": "miskatonicmysteries:obfuscated",
+      "type": "text",
       "stage": 1,
       "affiliation": "miskatonicmysteries:hastur",
       "obfuscated_text": "Hail the prince and kiss his cheek, or else your ascent will look bleak.",
-      "text": "The next step is somewhat more elaborate-$(br)In order to receive the first blessing, one must summon a $(l:miskatonicmysteries:bestiary/prince)$(marked)Tattered Prince$(), using the $(l:miskatonicmysteries:rites/golden_coronation)$(marked)Golden Coronation$().$(br)Once summoned, you may let him bless you by talking to him."
+      "text": "$(obfs:miskatonicmysteries:hastur;1)The next step is somewhat more elaborate-$(br)In order to receive the first blessing, one must summon a $(l:miskatonicmysteries:bestiary/prince)$(marked)Tattered Prince$(), using the $(l:miskatonicmysteries:rites/golden_coronation)$(marked)Golden Coronation$().$(br)Once summoned, you may let him bless you by talking to him."
     },
     {
-      "type": "miskatonicmysteries:obfuscated",
+      "type": "text",
       "stage": 2,
       "affiliation": "miskatonicmysteries:hastur",
       "obfuscated_text": "lol im too lazy to actually finish this so here have this for now",
-      "text": "For now, you feel yourself limited... perhaps the stars are not properly aligned yet?"
+      "text": "$(obfs:miskatonicmysteries:hastur;2)For now, you feel yourself limited... perhaps the stars are not properly aligned yet?"
     }
   ]
 }

--- a/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/world/intro.json
+++ b/src/main/resources/data/miskatonicmysteries/patchouli_books/necronomicon/en_us/entries/world/intro.json
@@ -18,7 +18,7 @@
     },
     {
       "type": "text",
-      "text": "$(obfs)If you can read this$(), you are probably ready for the higher mysteries of the art; remember that whatever path you chose is final. Only true death can separate you from it. $(br2)Unless?"
+      "text": "$(obfs:;1)If you can read this, you are probably ready for the higher mysteries of the art; remember that whatever path you chose is final. Only true death can separate you from it. $(br2)Unless?"
     }
   ]
 }


### PR DESCRIPTION
Since https://github.com/cybercat5555/Miskatonic-Mysteries-Fabric/commit/b37a13b978c1ca08d642fc076c0907dea40427f2, loading the book contents errors out due to the `miskatonicmysteries:obfuscated` template being removed while it's still in use for some entries.

I fixed the remaining entries and made sure the new `obfs` function is actually applied everywhere where it should (Patchouli functions require at least the `:`).
The only thing I did not test is the Golden Path.

I'm also assuming that the `obfuscated_title`, `stage`, `obfuscated_text` and `affiliation` fields can now be removed but did not do so.

---

Kinda offtopic but this change feels like a big step backwards since it doesn't use the obfuscated font, it simply doesn't look as good:

Before:
![before](https://user-images.githubusercontent.com/8464472/123433121-671d8f80-d5cb-11eb-99d0-18fade5b818c.png)

After:
![after](https://user-images.githubusercontent.com/8464472/123433129-68e75300-d5cb-11eb-9783-613b98d5383d.gif)

Is there a specific reason the custom renderer was removed? Perhaps due to a change in Patchouli?