### PR TITLE
Add requirement for midnightlib to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -54,7 +54,8 @@
 		"patchouli": ">=1.18.1-64-FABRIC",
 		"trinkets": ">=3.1.0",
 		"cloth-config2": "*",
-		"geckolib3": ">=3.0.30"
+		"geckolib3": ">=3.0.30",
+		"mignightlib": "*"
 	},
 	"custom": {
 		"cardinal-components": [


### PR DESCRIPTION
MM crashes with class not found errors if midnightlib is not installed, as it uses it for config. Without it being included in the fabric.mod.json, we do not get the usual helpful errors from fabric